### PR TITLE
Release/v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,10 @@
 ### Usage
 - maze_grid.txt 파일에서 '#' -> 구조물, '.' -> 빈공간
 - 원하는 미로 형식대로 구성 후 (왼쪽 밑이 0,0 좌표 / xy좌표계라 생각)
-- python3 make_maze_world.py --grid maze_3x3.world --out ~/tb3_explore/src/tb3_sim_bundle/worlds/maze_3x3.world
+- python3 make_maze_world.py --grid maze_grid.txt --out ~/tb3_explore/src/tb3_sim_bundle/worlds/maze_3x3.world
 
 - cd ~/tb3_explore
+- sudo chown -R "$USER":"$USER" ~/tb3_explore ## 권한 부여
 - colcon build --symlink-install --merge-install
 - source install/setup.bash
 - 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,13 @@
 ### Usage
 - maze_grid.txt 파일에서 '#' -> 구조물, '.' -> 빈공간
 - 원하는 미로 형식대로 구성 후 (왼쪽 밑이 0,0 좌표 / xy좌표계라 생각)
-- python3 make_maze_world.py --grid maze_grid.txt --out ~/tb3_explore/src/tb3_sim_bundle/worlds/maze_3x3.world
 
 - cd ~/tb3_explore
 - sudo chown -R "$USER":"$USER" ~/tb3_explore ## 권한 부여
+- python3 make_maze_world.py --grid maze_grid.txt --out ~/tb3_explore/src/tb3_sim_bundle/worlds/maze_3x3.world
+
+
+- cd ~/tb3_explore
 - colcon build --symlink-install --merge-install
 - source install/setup.bash
 - 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - `maze_3x3.world` 생성 로직 리팩터링 및 월드 리라이트.
 ### Usage
 - maze_grid.txt 파일에서 '#' -> 구조물, '.' -> 빈공간
-- 원하는 미로 형식대로 구성 후
+- 원하는 미로 형식대로 구성 후 (왼쪽 밑이 0,0 좌표 / xy좌표계라 생각)
 - python3 make_maze_world.py --grid maze_3x3.world --out ~/tb3_explore/src/tb3_sim_bundle/worlds/maze_3x3.world
 
 - cd ~/tb3_explore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+## [Unreleased]
+### Added
+- 
+
+### Changed
+- 
+
+### Fixed
+- 
+
+## [v1.1.0] - 2025-08-17
+### Added
+- 텍스트 그리드(`maze_grid.txt`)로 Gazebo world를 자동 생성하는 스크립트 `make_maze_world.py`.
+### Changed
+- `maze_3x3.world` 생성 로직 리팩터링 및 월드 리라이트.
+### Usage
+- maze_grid.txt 파일에서 '#' -> 구조물, '.' -> 빈공간
+- 원하는 미로 형식대로 구성 후
+- python3 make_maze_world.py --grid maze_3x3.world --out ~/tb3_explore/src/tb3_sim_bundle/worlds/maze_3x3.world
+
+- cd ~/tb3_explore
+- colcon build --symlink-install --merge-install
+- source install/setup.bash
+- 
+
+## [v1.0.0] - 2025-08-16
+### Added
+- 초기 릴리스.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # tb3_explore (ROS 2 Humble)
 
+## Requirements
+sudo apt install ros-humble-gazebo-ros-pkgs
+
+sudo apt install ros-humble-gazebo-ros
+
 ## Build
 colcon build --symlink-install --merge-install
 
@@ -7,13 +12,14 @@ source /opt/ros/humble/setup.bash
 
 source install/setup.bash
 
+ros2 pkg prefix tb3_sim_bundle ## ~/home/$USER/tb3_explore/install 뜨면 성공! 만약 이 경로가 안 뜰 시 밑의 export 2줄 실행해서 강제 경로 설정
 
 
 export AMENT_PREFIX_PATH="$AMENT_PREFIX_PATH:$HOME/tb3_explore/install"
 
 export COLCON_PREFIX_PATH="$HOME/tb3_explore/install"
 
-ros2 pkg prefix tb3_sim_bundle ## ~/home/$USER/tb3_explore/install 뜨면 성공!
+
 
 ## Run (SLAM + Nav2 + Frontier Explore)
 ros2 launch tb3_sim_bundle sim_explore.launch.py


### PR DESCRIPTION
## [v1.1.0] - 2025-08-17
### Added
- 텍스트 그리드(`maze_grid.txt`)로 Gazebo world를 자동 생성하는 스크립트 `make_maze_world.py`.
### Changed
- `maze_3x3.world` 생성 로직 리팩터링 및 월드 리라이트.
### Usage
- maze_grid.txt 파일에서 '#' -> 구조물, '.' -> 빈공간
- 원하는 미로 형식대로 구성 후
- python3 make_maze_world.py --grid maze_3x3.world --out ~/tb3_explore/src/tb3_sim_bundle/worlds/maze_3x3.world

- cd ~/tb3_explore
- colcon build --symlink-install --merge-install
- source install/setup.bash